### PR TITLE
Fixed: on time delivery rate calculation

### DIFF
--- a/purchase_orders/tests.py
+++ b/purchase_orders/tests.py
@@ -16,7 +16,7 @@ class PurchaseOrdersViewSetTestCase(TestCase):
             # contact_details = "Testing contact details",
             # address = "2 Central Street, Kolkata",
             # vendor_code = 23,
-            on_time_delivery_rate = 57.33,
+            on_time_delivery_rate = 51,
             quality_rating_avg = 34.4,
             average_response_time = 58,
             fulfillment_rate = 49.9,
@@ -26,23 +26,38 @@ class PurchaseOrdersViewSetTestCase(TestCase):
         #Testing on time delivery rate custom action with 0 completed purchase orders
         url = reverse('on_time_delivery_rate', args=[self.vendor.id])
         response = self.client.get(url)
+        order_date = "2012-3-21", 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['on_time_delivery_rate'], 0)
 
     def test_on_time_delivery_rate_with_completed_orders(self):
         #Testing on time delivery rate custom action with completed purchase orders
         on_time_purchase_order = PurchaseOrders.objects.create(
-            po_number = 2241,
-            vendor = 2,
-            delivery_date = timezone.now() + timezone.timedelta(days=5),
-            status = "COMPLETED",
+            vendor=self.vendor,
+            po_number = 2900,
+            order_date = "2012-3-21",
+            items = {
+                "title": "water bottle",
+                "itemId": 1,
+                "completed": True,
+            },
+            quantity = 14,
+            status="DONE",
+            delivery_date=timezone.now() + timezone.timedelta(days=5),
         )
 
         late_purchase_order = PurchaseOrders.objects.create(
-            po_number = 294,
-            vendor = 2,
-            delivery_date = timezone.now() + timezone.timedelta(days=5),
-            status = "COMPLETED",
+            vendor=self.vendor,
+            po_number = 223,
+            order_date = "2012-3-21",
+            items = {
+                "title": "water bottle",
+                "itemId": 1,
+                "completed": True,
+            },
+            quantity = 25,
+            status="DONE",
+            delivery_date=timezone.now() + timezone.timedelta(days=5),
         )
 
         url = reverse('on_time_delivery_rate', args=[self.vendor.id])
@@ -52,7 +67,7 @@ class PurchaseOrdersViewSetTestCase(TestCase):
 
     def test_on_time_delivery_rate_invalid_vendor_id(self):
         #Test the on_time_delivery_rate custom action with an invalid vendor ID.
-        url = reverse('on_time_delivery_rate', args=[])
+        url = reverse('on_time_delivery_rate', args=[999])
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {'error': 'Vendor ID is required.'})

--- a/purchase_orders/views.py
+++ b/purchase_orders/views.py
@@ -1,12 +1,9 @@
-from django.shortcuts import render
 from django.db.models import F
 from .models import PurchaseOrders
 from .serializers import PurchaseOrderSerializer
 from rest_framework import generics, viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-
-# Create your views here.
 
 class PurchaseOrdersList(generics.ListCreateAPIView):
     queryset = PurchaseOrders.objects.all()
@@ -28,14 +25,17 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             status=status.HTTP_400_BAD_REQUEST
         )
         completed_purchase_order = PurchaseOrders.objects.filter(
-            vendor_id=vendor_id, status='completed')
+            vendor_id=vendor_id, status='COMPLETE')
+
         on_time_count = completed_purchase_order.filter(
             delivery_date__lte=F('delivery_date')).count()
+        
         total_count = completed_purchase_order.count()
         if total_count == 0: return Response(
             {'on_time_delivery_rate': 0}
         )
+
         on_time_delivery_rate = (on_time_count / total_count) * 100
         return Response({
-            'on_time_delivery_rate': on_time_delivery_rate
+            'on_time_delivery_rate': on_time_delivery_rate,
         })


### PR DESCRIPTION
Fixed the "on time delivery rate" calculation implementation in logic by:
1. Ensuring it is calculated each time a PO 'status' changes to 'COMPLETE'
2. Counting the number of completed Purchase Orders delivered on or before
delivery_date and dividing by the total number of completed Purchase Orders for that vendor